### PR TITLE
fix: Remove check for more than 1 window in running apps

### DIFF
--- a/Triggrd.spoon/init.lua
+++ b/Triggrd.spoon/init.lua
@@ -56,10 +56,7 @@ function Triggrd:start()
     Triggrd.runningApps = {}
 
     for _,app in ipairs(hs.application.runningApplications()) do
-        -- Does the app have any windows? If not, we are adding a ton of unnecessary apps like voiceover, com.apple.speechsynthesis, etc.
-        if (#app:allWindows() > 0) then
-            table.insert(Triggrd.runningApps, Triggrd.generateAppListItem(Triggrd, app))
-        end
+        table.insert(Triggrd.runningApps, Triggrd.generateAppListItem(Triggrd, app))
     end
     Triggrd:createMenubar()
     loadfile(hs.spoons.resourcePath("events.lua"))(Triggrd)


### PR DESCRIPTION
I just noticed that that check I put in place to add running apps with more than 1 window was adding 6 seconds of processing time, fml. This way is cleaner anyway.